### PR TITLE
chore(links): update file a bug link and downloads to point to upstream repo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -139,7 +139,7 @@ layout: default
     <div class="p-card col-6">
       <h3 class="p-card__title">Download</h3>
       <p class="p-card__content">Download the officially released archives.</p>
-      <a href="https://launchpad.net/cloud-init/+download">Download project files</a>
+      <a href="https://github.com/canonical/cloud-init/releases">Download project files</a>
     </div>
   </div>
 </section>
@@ -212,7 +212,7 @@ layout: default
     </div>
     <div class="col-3 p-card">
       <h4>
-        <a href="https://bugs.launchpad.net/cloud-init/+filebug">Report a bug</a>
+        <a href="https://github.com/canonical/cloud-init/issues/new/choose">Report a bug</a>
       </h4>
       <p>Help us improve the software by flagging bugs and issues you find on Launchpad.</p>
     </div>


### PR DESCRIPTION
Github issues and the github release page is preferred over launchpad pages for new bugs/releases.