### PR TITLE
WD-14950 - update Ubuntu and Google Cloud logos

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -73,7 +73,7 @@ layout: default
   <div class="row">
     <div class="p-card col-3">
       <header class="p-card__header">
-        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu logo">
+        <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/0f5a9c27-Ubuntu-Logo-Light@2x.png" alt="Ubuntu logo">
       </header>
       <a href="https://launchpad.net/ubuntu/+source/cloud-init">Get packages</a>
     </div>
@@ -171,7 +171,7 @@ layout: default
           <img class="p-inline-section__logo" src="https://assets.ubuntu.com/v1/8d9986ed-2018-logo-Fujitsu.svg" alt="Fujitsu">
         </div>
         <div class="p-logo-section__item">
-          <img class="p-inline-section__logo" src="https://assets.ubuntu.com/v1/410984a3-Google-cloud-platform-stacked.svg" alt="Google Cloud Platform">
+          <img class="p-inline-section__logo" src="https://assets.ubuntu.com/v1/34ac6b2d-lockup_GoogleCloud_FullColor_rgb_2900x512px.png" alt="Google Cloud Platform">
         </div>
         <div class="p-logo-section__item">
           <img class="p-inline-section__logo" src="https://assets.ubuntu.com/v1/debf01e1-Oracle-Cloud-Logo-350.png" alt="Oracle Cloud">


### PR DESCRIPTION
## Done

Updated Ubuntu and Google Cloud logos

## QA
- [demo link](https://cloud-init-io-275.demos.haus/)
- Check the site on the demo
- Check that the logos are updated

## Issue / Card
[WD-14950](https://warthogs.atlassian.net/browse/WD-14950)

[WD-14950]: https://warthogs.atlassian.net/browse/WD-14950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ